### PR TITLE
Add lint config & alert summaries

### DIFF
--- a/contrib/mixin/.lint
+++ b/contrib/mixin/.lint
@@ -1,0 +1,18 @@
+---
+exclusions:
+  template-instance-rule:
+    reason: The mixin only uses `instance` for alerts, and `cluster` for dashboard queries
+  template-job-rule:
+    reason: The dashboards use 'cluster' label as selector, rather than 'job'
+  target-job-rule:
+    reason: The mixin uses 'cluster' instead of 'job'
+  target-instance-rule:
+    reason: The mixin only uses `instance` for alerts, and `cluster` for dashboard queries
+  alert-name-camelcase:
+    reason: etcd is spelled all lowercase, meaning all alert name start with a lowercase
+  alert-summary-style:
+    reason: etcd is spelled all lowercase, meaning summaries starting with 'etcd' are still valid
+  panel-units-rule:
+    reason: Stat panels have no unit, and some panels use custom unit or text
+  panel-title-description-rule:
+    reason: Suppress noisy linting rule until we can address minor tech debt like this

--- a/contrib/mixin/mixin.libsonnet
+++ b/contrib/mixin/mixin.libsonnet
@@ -192,6 +192,7 @@
             },
             annotations: {
               description: 'etcd cluster "{{ $labels.%s }}": 99th percentile fsync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.' % $._config.clusterLabel,
+              summary: 'etcd cluster 99th percentile fsync durations are critically high.',
             },
           },
           {
@@ -220,6 +221,7 @@
             },
             annotations: {
               description: 'etcd cluster "{{ $labels.%s }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.' % $._config.clusterLabel,
+              summary: 'etcd cluster 99th percentile commit durations are critically high.',
             },
           },
           {
@@ -233,6 +235,7 @@
             },
             annotations: {
               description: 'etcd cluster "{{ $labels.%s }}": Observed surge in etcd writes leading to 50%% increase in database size over the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.' % $._config.clusterLabel,
+              summary: 'etcd cluser database is experiencing excessive growth.',
             },
           },
         ],


### PR DESCRIPTION
This PR introduces a lint config for the mixin to suppress irrelevant and noisy lint rules, and adds missing alert summaries.

